### PR TITLE
LaravelSequenceResolver 序列缓存10秒

### DIFF
--- a/src/LaravelSequenceResolver.php
+++ b/src/LaravelSequenceResolver.php
@@ -36,7 +36,7 @@ class LaravelSequenceResolver implements SequenceResolver
     {
         $key = $currentTime;
 
-        if ($this->cache->add($key, 1, 1)) {
+        if ($this->cache->add($key, 1, 10)) {
             return 0;
         }
 


### PR DESCRIPTION
感谢写了这么好的库 ：）

我看到 RedisSequenceResolver 中缓存时间由1s 改为了 10s , 不知这里能否将 LaravelSequenceResolver 方便改成10s。如果设置为10s，就能应对10s 以内的时间回拨问题，所以发个pr

另外，想知道介意我 fork 此仓库，并封装成一个 laravel 扩展么？