### PR TITLE
feat: Helpers for generating ID's for specified time

### DIFF
--- a/src/IdGenerator.php
+++ b/src/IdGenerator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the godruoyi/php-snowflake.
+ *
+ * (c) Godruoyi <g@godruoyi.com>
+ *
+ * This source file is subject to the MIT license that is bundled.
+ */
+
+namespace Godruoyi\Snowflake;
+
+use Closure;
+
+interface IdGenerator
+{
+    /**
+     * Get snowflake id.
+     *
+     * @throws SnowflakeException
+     */
+    public function id(): string;
+
+    /**
+     * Get snowflake id for specific timestamp.
+     *
+     * @throws SnowflakeException
+     */
+    public function idFor(\DateTime|int $timestamp): string;
+
+    /**
+     * Parse snowflake id.
+     *
+     * @return array<string, float|int|string>
+     */
+    public function parseId(string $id, bool $transform = false): array;
+
+    /**
+     * Calculate the unix timestamp from a given timestamp relative to the start time.
+     */
+    public function toMicrotime(int $timestamp): float|int;
+
+    /**
+     * Get current millisecond time.
+     */
+    public function getCurrentMillisecond(): int;
+
+    /**
+     * Set start time (millisecond).
+     *
+     * @throws SnowflakeException
+     */
+    public function setStartTimeStamp(int $millisecond): self;
+
+    /**
+     * Get start timestamp (millisecond), If not set default to 2019-08-08 08:08:08.
+     */
+    public function getStartTimeStamp(): float|int;
+
+    /**
+     * Set Sequence Resolver.
+     */
+    public function setSequenceResolver(Closure|SequenceResolver $sequence): self;
+
+    /**
+     * Get Sequence Resolver.
+     */
+    public function getSequenceResolver(): null|Closure|SequenceResolver;
+
+    /**
+     * Get Default Sequence Resolver.
+     */
+    public function getDefaultSequenceResolver(): SequenceResolver;
+}

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -137,6 +137,14 @@ class Snowflake
     }
 
     /**
+     * Calculate the unix timestamp from a given timestamp relative to the start time.
+     */
+    public function toMicrotime(int $timestamp): float|int
+    {
+        return $timestamp + $this->getStartTimeStamp();
+    }
+
+    /**
      * Get current millisecond time.
      */
     public function getCurrentMillisecond(): int

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -14,7 +14,7 @@ namespace Godruoyi\Snowflake;
 
 use Closure;
 
-class Snowflake
+class Snowflake implements IdGenerator
 {
     public const MAX_TIMESTAMP_LENGTH = 41;
 

--- a/src/Sonyflake.php
+++ b/src/Sonyflake.php
@@ -89,6 +89,14 @@ class Sonyflake extends Snowflake
     }
 
     /**
+     * Calculate the unix timestamp from a given timestamp relative to the start time.
+     */
+    public function toMicrotime(int $timestamp): float|int
+    {
+        return $timestamp * 10 + $this->getStartTimeStamp();
+    }
+
+    /**
      * Set start time (millisecond).
      *
      * @throws SnowflakeException

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -303,5 +303,18 @@ class SnowflakeTest extends TestCase
             'datacenter' => $datacenter,
         ], $parsed);
         $this->assertEquals($expectedId, $id);
+        $this->assertEquals($expectedTimestamp, $snowflake->toMicrotime((int) $parsed['timestamp']));
+    }
+
+    public function test_interpretation_of_timestamps(): void
+    {
+        $startTimestamp = strtotime('2019-08-08 08:08:08') * 1000;
+        $expectedTimestamp = 1577836800000;
+        $timestamp = 1577836800000 - $startTimestamp;
+
+        $snowflake = new Snowflake(999, 20);
+        $snowflake->setStartTimeStamp($startTimestamp);
+
+        $this->assertEquals($expectedTimestamp, $snowflake->toMicrotime($timestamp));
     }
 }

--- a/tests/SonyflakeTest.php
+++ b/tests/SonyflakeTest.php
@@ -177,6 +177,7 @@ class SonyflakeTest extends TestCase
             'machineid' => $worker,
         ], $parsed);
         $this->assertEquals($expectedId, $id);
+        $this->assertEquals($expectedTimestamp, $snowflake->toMicrotime((int) $parsed['timestamp']));
     }
 
     public function test_get_default_sequence_resolver(): void
@@ -216,5 +217,17 @@ class SonyflakeTest extends TestCase
         $time = $snowflake->getCurrentMillisecond();
 
         $this->assertTrue($now - $time >= 0);
+    }
+
+    public function test_interpretation_of_timestamps(): void
+    {
+        $startTimestamp = strtotime('2019-08-08 08:08:08') * 1000;
+        $expectedTimestamp = 1577836800000;
+        $timestamp = (int) floor((1577836800000 - $startTimestamp) / 10);
+
+        $snowflake = new Sonyflake(9990);
+        $snowflake->setStartTimeStamp($startTimestamp);
+
+        $this->assertEquals($expectedTimestamp, $snowflake->toMicrotime($timestamp));
     }
 }


### PR DESCRIPTION
This PR provides helper for generating Snowflake ID for a specified time, for use in tests or when retrospectively adding Snowflake ID's to existing database: d0cac91f1a6a03ee3a71fd0846edaf796a8833f5
- 9442f82e623b77da630e531d44983356921fd511 Add `Snowflake::idFor($timestamp)` method
- d0cac91f1a6a03ee3a71fd0846edaf796a8833f5  Add `Sonyflake::idFor($timestamp)` method

Second added helper, eases conversion from relative timestamps returned from `Snowflake::parseId($id, $transform)` method to unix microtime:
- a830e0f75fb044aefc27ffe921342bfcaeac6bc9 Add `Snowflake::toMicrotime($timestamp)` method
- 77c1fb5801a38cb4f0fed915a143779a695b5d64 Add `Sonyflake::toMicrotime($timestamp)` method

And finally I have extracted an interface for easier playing with dependency injection container:
- ac2a96032f5eee7d643828f0712ed0dab0609e14 Extract IdGenerator interface