### PR TITLE
delete unstable tests and skip redis tests if the redis extension is not installed

### DIFF
--- a/tests/BatchSnowflakeIDTest.php
+++ b/tests/BatchSnowflakeIDTest.php
@@ -35,19 +35,6 @@ class BatchSnowflakeIDTest extends TestCase
         $this->assertCount($count, $ids);
     }
 
-    public function test_batch_for_diff_instance_with_default_driver(): void
-    {
-        $ids = [];
-        $count = 100_000; // 100k
-
-        for ($i = 0; $i < $count; $i++) {
-            $ids[(new Snowflake())->id()] = 1;
-        }
-
-        // This pattern will result in generating duplicate IDs.
-        $this->assertGreaterThan(90000, count($ids));
-    }
-
     /**
      * @throws Throwable
      */

--- a/tests/FileLockResolverTest.php
+++ b/tests/FileLockResolverTest.php
@@ -18,6 +18,7 @@ use Godruoyi\Snowflake\SnowflakeException;
 class FileLockResolverTest extends TestCase
 {
     private FileLockResolver $fileLocker;
+
     /** @var callable */
     private $defer;
 

--- a/tests/RedisSequenceResolverTest.php
+++ b/tests/RedisSequenceResolverTest.php
@@ -17,6 +17,13 @@ use RedisException;
 
 class RedisSequenceResolverTest extends TestCase
 {
+    public function setUp(): void
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('Redis extension is not installed');
+        }
+    }
+
     public function test_invalid_redis_connect(): void
     {
         $redis = $this->createMock(\Redis::class);
@@ -57,10 +64,6 @@ class RedisSequenceResolverTest extends TestCase
      */
     public function test_real_redis(): void
     {
-        if (! extension_loaded('redis')) {
-            $this->markTestSkipped('Redis extension is not installed.');
-        }
-
         if (! ($host = getenv('REDIS_HOST')) || ! ($port = getenv('REDIS_PORT'))) {
             $this->markTestSkipped('Redis host or port is not set, skip real redis test.');
         }


### PR DESCRIPTION
This test has always been unstable here, we've directly deleted it and no longer recommend using the default RandomSequenceResolver. If you need to ensure your ID is unique, you might want to look at FileLockResolver.
```php
public function test_batch_for_diff_instance_with_default_driver(): void
    {
        $ids = [];
        $count = 100_000; // 100k

        for ($i = 0; $i < $count; $i++) {
            $ids[(new Snowflake())->id()] = 1;
        }

        // This pattern will result in generating duplicate IDs.
        $this->assertGreaterThan(90000, count($ids));
    }
```