### PR TITLE
add idForTimestamp()

### DIFF
--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -86,11 +86,11 @@ class Snowflake
      * @return string
      * @throws SnowflakeException
      */
-    public function idForTimestamp($timestamp): string
+    public function idForTimestamp(int|DateTimeInterface $timestamp): string
     {
-        $currentTime = (int) ($timestamp instanceof DateTimeInterface
-            ? $timestamp->format('Uv')
-            : $timestamp);
+        $currentTime = $timestamp instanceof DateTimeInterface
+            ? (int) $timestamp->format('Uv')
+            : $timestamp;
 
         // Validate timestamp is not earlier than start time
         $startTime = $this->getStartTimeStamp();

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -54,7 +54,7 @@ class Snowflake
     /**
      * The current time resolver.
      *
-     * @var (Closure(): int)|null
+     * @var (Closure(): float)|null
      */
     protected ?Closure $timeResolver = null;
 
@@ -118,7 +118,13 @@ class Snowflake
      */
     public function getCurrentMillisecond(): int
     {
-        return $this->timeResolver === null ? floor(microtime(true) * 1000) | 0 : call_user_func($this->timeResolver);
+        return floor(
+            (
+                $this->timeResolver === null
+                    ? microtime(true)
+                    : call_user_func($this->timeResolver)
+            ) * 1000
+        ) | 0;
     }
 
     /**
@@ -137,7 +143,10 @@ class Snowflake
         $maxTimeDiff = -1 ^ (-1 << self::MAX_TIMESTAMP_LENGTH);
 
         if ($missTime > $maxTimeDiff) {
-            throw new SnowflakeException(sprintf('The current microtime - starttime is not allowed to exceed -1 ^ (-1 << %d), You can reset the start time to fix this', self::MAX_TIMESTAMP_LENGTH));
+            throw new SnowflakeException(sprintf(
+                'The current microtime - starttime is not allowed to exceed -1 ^ (-1 << %d), You can reset the start time to fix this',
+                self::MAX_TIMESTAMP_LENGTH
+            ));
         }
 
         $this->startTime = $millisecond;
@@ -150,7 +159,7 @@ class Snowflake
      */
     public function getStartTimeStamp(): float|int
     {
-        if (! is_null($this->startTime)) {
+        if (!is_null($this->startTime)) {
             return $this->startTime;
         }
 
@@ -189,9 +198,9 @@ class Snowflake
     /**
      * Set the time resolver.
      *
-     * @param  (Closure(): int)|null  $timeResolver
+     * @param  (Closure(): float)|null  $timeResolver
      */
-    public function setTimeResolver(Closure|null $timeResolver): self
+    public function setCurrentTimeResolver(Closure|null $timeResolver): self
     {
         $this->timeResolver = $timeResolver;
 
@@ -201,9 +210,9 @@ class Snowflake
     /**
      * Get the time resolver.
      *
-     * @return (Closure(): int)|null
+     * @return (Closure(): float)|null
      */
-    public function getTimeResolver(): Closure|null
+    public function getCurrentTimeResolver(): Closure|null
     {
         return $this->timeResolver;
     }
@@ -215,11 +224,11 @@ class Snowflake
     {
         $resolver = $this->getSequenceResolver();
 
-        if (! is_null($resolver) && is_callable($resolver)) {
+        if (!is_null($resolver) && is_callable($resolver)) {
             return $resolver($currentTime);
         }
 
-        return ! ($resolver instanceof SequenceResolver)
+        return !($resolver instanceof SequenceResolver)
             ? $this->getDefaultSequenceResolver()->sequence($currentTime)
             : $resolver->sequence($currentTime);
     }

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -53,6 +53,8 @@ class Snowflake
 
     /**
      * The current time resolver.
+     *
+     * @var (Closure(): int)|null
      */
     protected ?Closure $timeResolver = null;
 
@@ -182,6 +184,28 @@ class Snowflake
     public function getDefaultSequenceResolver(): SequenceResolver
     {
         return $this->defaultSequenceResolver ?: $this->defaultSequenceResolver = new RandomSequenceResolver();
+    }
+
+    /**
+     * Set the time resolver.
+     *
+     * @param  (Closure(): int)|null  $timeResolver
+     */
+    public function setTimeResolver(Closure|null $timeResolver): self
+    {
+        $this->timeResolver = $timeResolver;
+
+        return $this;
+    }
+
+    /**
+     * Get the time resolver.
+     *
+     * @return (Closure(): int)|null
+     */
+    public function getTimeResolver(): Closure|null
+    {
+        return $this->timeResolver;
     }
 
     /**

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Godruoyi\Snowflake;
 
 use Closure;
+use DateTimeInterface;
 
 class Snowflake
 {
@@ -52,13 +53,6 @@ class Snowflake
     protected ?SequenceResolver $defaultSequenceResolver = null;
 
     /**
-     * The current time resolver.
-     *
-     * @var (Closure(): float)|null
-     */
-    protected ?Closure $timeResolver = null;
-
-    /**
      * Build Snowflake Instance.
      */
     public function __construct(int $datacenter = -1, int $workerId = -1)
@@ -82,11 +76,43 @@ class Snowflake
             $currentTime = $this->getCurrentMillisecond();
         }
 
+        return $this->buildId($currentTime, $this->getStartTimeStamp(), $sequence);
+    }
+
+    /**
+     * Generate snowflake id for a specific timestamp.
+     *
+     * @param  int|DateTimeInterface $timestamp The timestamp to generate ID for (in milliseconds or DateTime object)
+     * @return string
+     * @throws SnowflakeException
+     */
+    public function idForTimestamp($timestamp): string
+    {
+        $currentTime = (int) ($timestamp instanceof DateTimeInterface
+            ? $timestamp->format('Uv')
+            : $timestamp);
+
+        // Validate timestamp is not earlier than start time
+        $startTime = $this->getStartTimeStamp();
+        if ($currentTime < $startTime) {
+            throw new SnowflakeException('The provided timestamp cannot be earlier than the start time');
+        }
+
+        // Get sequence number (auto-increment if overflow)
+        while (($sequence = $this->callResolver($currentTime)) > (-1 ^ (-1 << self::MAX_SEQUENCE_LENGTH))) {
+            $currentTime++;
+        }
+
+        return $this->buildId($currentTime, $startTime, $sequence);
+    }
+
+    protected function buildId(int $currentTime, float|int $startTime, int $sequence): string
+    {
         $workerLeftMoveLength = self::MAX_SEQUENCE_LENGTH;
         $datacenterLeftMoveLength = self::MAX_WORKID_LENGTH + $workerLeftMoveLength;
         $timestampLeftMoveLength = self::MAX_DATACENTER_LENGTH + $datacenterLeftMoveLength;
 
-        return (string) ((($currentTime - $this->getStartTimeStamp()) << $timestampLeftMoveLength)
+        return (string) ((($currentTime - $startTime) << $timestampLeftMoveLength)
             | ($this->datacenter << $datacenterLeftMoveLength)
             | ($this->workerId << $workerLeftMoveLength)
             | ($sequence));
@@ -118,13 +144,7 @@ class Snowflake
      */
     public function getCurrentMillisecond(): int
     {
-        return floor(
-            (
-                $this->timeResolver === null
-                    ? microtime(true)
-                    : call_user_func($this->timeResolver)
-            ) * 1000
-        ) | 0;
+        return floor(microtime(true) * 1000) | 0;
     }
 
     /**
@@ -193,28 +213,6 @@ class Snowflake
     public function getDefaultSequenceResolver(): SequenceResolver
     {
         return $this->defaultSequenceResolver ?: $this->defaultSequenceResolver = new RandomSequenceResolver();
-    }
-
-    /**
-     * Set the time resolver.
-     *
-     * @param  (Closure(): float)|null  $timeResolver
-     */
-    public function setCurrentTimeResolver(Closure|null $timeResolver): self
-    {
-        $this->timeResolver = $timeResolver;
-
-        return $this;
-    }
-
-    /**
-     * Get the time resolver.
-     *
-     * @return (Closure(): float)|null
-     */
-    public function getCurrentTimeResolver(): Closure|null
-    {
-        return $this->timeResolver;
     }
 
     /**

--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -52,6 +52,11 @@ class Snowflake
     protected ?SequenceResolver $defaultSequenceResolver = null;
 
     /**
+     * The current time resolver.
+     */
+    protected ?Closure $timeResolver = null;
+
+    /**
      * Build Snowflake Instance.
      */
     public function __construct(int $datacenter = -1, int $workerId = -1)
@@ -111,7 +116,7 @@ class Snowflake
      */
     public function getCurrentMillisecond(): int
     {
-        return floor(microtime(true) * 1000) | 0;
+        return $this->timeResolver === null ? floor(microtime(true) * 1000) | 0 : call_user_func($this->timeResolver);
     }
 
     /**

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -213,16 +213,23 @@ class SnowflakeTest extends TestCase
     public function test_time_resolver(): void
     {
         $snowflake = new Snowflake(999, 20);
-        $snowflake->setTimeResolver(function (): int {
-            return 2832794913314;
+
+        // Same contract as microtime(true): seconds since Unix epoch (float).
+        // Pick an absolute instant in ms, as if derived from a row's created_at.
+        $currentMs = 2_832_794_913_314;
+        $unixSeconds = $currentMs / 1000.0;
+
+        $snowflake->setCurrentTimeResolver(static function () use ($unixSeconds): float {
+            return $unixSeconds;
         });
 
-        $resolver = $snowflake->getTimeResolver();
+        $resolver = $snowflake->getCurrentTimeResolver();
         $this->assertInstanceOf(Closure::class, $resolver);
-        $this->assertSame(2832794913314, $resolver());
+        $this->assertSame($unixSeconds, $resolver());
 
         $id = $snowflake->id();
-        $this->assertSame(1267543225314, $snowflake->parseId($id, true)['timestamp']);
+        $expectedTs = (int) floor($unixSeconds * 1000) - (int) $snowflake->getStartTimeStamp();
+        $this->assertSame($expectedTs, $snowflake->parseId($id, true)['timestamp']);
     }
 
     public function test_get_sequence_resolver(): void

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 namespace Tests;
 
 use Closure;
+use DateTime;
 use Godruoyi\Snowflake\RandomSequenceResolver;
 use Godruoyi\Snowflake\SequenceResolver;
 use Godruoyi\Snowflake\Snowflake;
+use Godruoyi\Snowflake\SnowflakeException;
 
 class SnowflakeTest extends TestCase
 {
@@ -210,28 +212,6 @@ class SnowflakeTest extends TestCase
         $this->assertTrue($seq(0) === 999);
     }
 
-    public function test_time_resolver(): void
-    {
-        $snowflake = new Snowflake(999, 20);
-
-        // Same contract as microtime(true): seconds since Unix epoch (float).
-        // Pick an absolute instant in ms, as if derived from a row's created_at.
-        $currentMs = 2_832_794_913_314;
-        $unixSeconds = $currentMs / 1000.0;
-
-        $snowflake->setCurrentTimeResolver(static function () use ($unixSeconds): float {
-            return $unixSeconds;
-        });
-
-        $resolver = $snowflake->getCurrentTimeResolver();
-        $this->assertInstanceOf(Closure::class, $resolver);
-        $this->assertSame($unixSeconds, $resolver());
-
-        $id = $snowflake->id();
-        $expectedTs = (int) floor($unixSeconds * 1000) - (int) $snowflake->getStartTimeStamp();
-        $this->assertSame($expectedTs, $snowflake->parseId($id, true)['timestamp']);
-    }
-
     public function test_get_sequence_resolver(): void
     {
         $snowflake = new Snowflake(999, 20);
@@ -286,5 +266,49 @@ class SnowflakeTest extends TestCase
         });
 
         $this->assertNotEmpty($snowflake->id());
+    }
+
+    /** @dataProvider idForTimestampDataProvider */
+    public function test_id_for_timestamp(DateTime|int $dt): void
+    {
+        $snowflake = new Snowflake(10, 1);
+        $snowflake->setStartTimeStamp((new DateTime('2026-04-22T00:00:00.000Z'))->getTimestamp() * 1000);
+        $id = $snowflake->idForTimestamp($dt);
+        $parsed = $snowflake->parseId($id, true);
+        $this->assertEquals(10, $parsed['datacenter']);
+        $this->assertEquals(1, $parsed['workerid']);
+        $timestamp = $parsed['timestamp'];
+
+        $parsedDt = new DateTime();
+        $parsedDt->setTimestamp($timestamp);
+        $this->assertEquals(60 * 60 * 1000, $parsedDt->getTimestamp());
+    }
+
+    public static function idForTimestampDataProvider(): array
+    {
+        return [
+            'datetime' => [new DateTime('2026-04-22T01:00:00.000Z')],
+            'timestamp' => [strtotime('2026-04-22T01:00:00.000Z') * 1000],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidIdForTimestampDataProvider
+     */
+    public function test_cannot_create_id_for_timestamp_when_timestamp_is_before_start_time(DateTime|int $invalidDt): void
+    {
+        $this->expectException(SnowflakeException::class);
+        $this->expectExceptionMessage('The provided timestamp cannot be earlier than the start time');
+        $snowflake = new Snowflake(10, 1);
+        $snowflake->setStartTimeStamp((new DateTime('2026-04-22T00:00:00.000Z'))->getTimestamp() * 1000);
+        $snowflake->idForTimestamp($invalidDt);
+    }
+
+    public static function invalidIdForTimestampDataProvider(): array
+    {
+        return [
+            'as datetime' => [new DateTime('2025-01-01T00:00:00.000Z')],
+            'as timestamp' => [strtotime('1900-01-01') * 1000],
+        ];
     }
 }

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -279,9 +279,7 @@ class SnowflakeTest extends TestCase
         $this->assertEquals(1, $parsed['workerid']);
         $timestamp = $parsed['timestamp'];
 
-        $parsedDt = new DateTime();
-        $parsedDt->setTimestamp($timestamp);
-        $this->assertEquals(60 * 60 * 1000, $parsedDt->getTimestamp());
+        $this->assertEquals(60 * 60 * 1000, $timestamp);
     }
 
     public static function idForTimestampDataProvider(): array

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -214,15 +214,15 @@ class SnowflakeTest extends TestCase
     {
         $snowflake = new Snowflake(999, 20);
         $snowflake->setTimeResolver(function (): int {
-            return 90210;
+            return 2832794913314;
         });
 
         $resolver = $snowflake->getTimeResolver();
         $this->assertInstanceOf(Closure::class, $resolver);
-        $this->assertSame(90210, $resolver());
+        $this->assertSame(2832794913314, $resolver());
 
         $id = $snowflake->id();
-        $this->assertSame(90210, $snowflake->parseId($id, true)['timestamp']);
+        $this->assertSame(1267543225314, $snowflake->parseId($id, true)['timestamp']);
     }
 
     public function test_get_sequence_resolver(): void

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -210,6 +210,21 @@ class SnowflakeTest extends TestCase
         $this->assertTrue($seq(0) === 999);
     }
 
+    public function test_time_resolver(): void
+    {
+        $snowflake = new Snowflake(999, 20);
+        $snowflake->setTimeResolver(function(): int {
+            return 90210;
+        });
+
+        $resolver = $snowflake->getTimeResolver();
+        $this->assertInstanceOf(Closure::class, $resolver);
+        $this->assertSame(90210, $resolver());
+
+        $id = $snowflake->id();
+        $this->assertSame(90210, $snowflake->parseId($id, true)['timestamp']);
+    }
+
     public function test_get_sequence_resolver(): void
     {
         $snowflake = new Snowflake(999, 20);

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -213,7 +213,7 @@ class SnowflakeTest extends TestCase
     public function test_time_resolver(): void
     {
         $snowflake = new Snowflake(999, 20);
-        $snowflake->setTimeResolver(function(): int {
+        $snowflake->setTimeResolver(function (): int {
             return 90210;
         });
 


### PR DESCRIPTION
My team is working on back-filling snowflake IDs for a number of database records. It would be really nice to be able to pull the DB record's `created_at` timestamp and use that when generating the historic Snowflake IDs.